### PR TITLE
外部API認証

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,9 +68,14 @@ jobs:
           command: |
             if [ $CIRCLE_BRANCH == master ]; then
               echo "export APP_NAME=amorer" >> $BASH_ENV
+              echo "export FACEBOOK_APP_ID=$FACEBOOK_APP_ID" >> $BASH_ENV
+              echo "export FACEBOOK_APP_SECRET=$FACEBOOK_APP_SECRET" >> $BASH_ENV
             else
               echo "export APP_NAME=amorer-sample" >> $BASH_ENV
+              echo "export FACEBOOK_APP_ID=$SAMPLE_FACEBOOK_APP_ID" >> $BASH_ENV
+              echo "export FACEBOOK_APP_SECRET=$SAMPLE_FACEBOOK_APP_SECRET" >> $BASH_ENV
             fi
+            heroku git:remote -a $APP_NAME
       - run:
           name: Deploy
           command: |
@@ -78,19 +83,20 @@ jobs:
       - run:
           name: Set database, if necessary
           command: |
-            if [ -z `heroku config:get JAWSDB_URL --app $APP_NAME` ]; then
-              heroku addons:create jawsdb --app $APP_NAME
-              DATABASE_URL=`heroku config:get JAWSDB_URL --app $APP_NAME`
+            if [ -z `heroku config:get JAWSDB_URL` ]; then
+              heroku addons:create jawsdb
+              DATABASE_URL=`heroku config:get JAWSDB_URL`
               DATABASE_URL2=${DATABASE_URL/mysql/mysql2}
-              heroku config:set DATABASE_URL=$DATABASE_URL2 --app $APP_NAME
+              heroku config:set DATABASE_URL=$DATABASE_URL2
             else
               echo "Database has been already set."
             fi
       - run:
           name: Run post-deploy tasks
           command: |
-            heroku config:set AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY_ID=$AWS_SECRET_ACCESS_KEY_ID BUCKET=$APP_NAME --app $APP_NAME
-            heroku run --app $APP_NAME rails db:migrate
+            heroku config:set AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY_ID=$AWS_SECRET_ACCESS_KEY_ID BUCKET=$APP_NAME
+            heroku config:set FACEBOOK_APP_ID=$FACEBOOK_APP_ID FACEBOOK_APP_SECRET=$FACEBOOK_APP_SECRET
+            heroku run rails db:migrate
 
 workflows:
   version: 2.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ jobs:
               echo "Heroku is already installed. No operation was performed."
             fi
       - run:
-          name: App_name setting by Branch
+          name: Environment variables by Branch
           command: |
             if [ $CIRCLE_BRANCH == master ]; then
               echo "export APP_NAME=amorer" >> $BASH_ENV
@@ -75,7 +75,10 @@ jobs:
               echo "export FACEBOOK_APP_ID=$SAMPLE_FACEBOOK_APP_ID" >> $BASH_ENV
               echo "export FACEBOOK_APP_SECRET=$SAMPLE_FACEBOOK_APP_SECRET" >> $BASH_ENV
             fi
-            heroku git:remote -a $APP_NAME
+      - run:
+          name: App_name setting
+          command: |
+            heroku git:remote --app $APP_NAME
       - run:
           name: Deploy
           command: |

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ yarn-debug.log*
 /stop
 
 /package-lock.json
+
+/.env

--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,8 @@ gem 'erb_lint', require: false
 
 gem 'devise'
 gem 'devise-i18n'
+gem 'omniauth'
+gem 'omniauth-facebook'
 
 gem 'will_paginate'
 gem 'bootstrap-will_paginate'
@@ -49,9 +51,9 @@ gem 'active_storage_validations'
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
-
   gem "rspec-rails"
   gem "factory_bot_rails"
+  gem 'dotenv-rails'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,6 +133,10 @@ GEM
     devise-i18n (1.9.2)
       devise (>= 4.7.1)
     diff-lcs (1.4.4)
+    dotenv (2.7.6)
+    dotenv-rails (2.7.6)
+      dotenv (= 2.7.6)
+      railties (>= 3.2)
     erb_lint (0.0.30)
       activesupport
       better_html (~> 1.0.7)
@@ -146,9 +150,12 @@ GEM
     factory_bot_rails (6.1.0)
       factory_bot (~> 6.1.0)
       railties (>= 5.0.0)
+    faraday (1.0.1)
+      multipart-post (>= 1.2, < 3)
     ffi (1.13.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    hashie (4.1.0)
     html_tokenizer (0.0.7)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
@@ -159,6 +166,7 @@ GEM
     jbuilder (2.10.0)
       activesupport (>= 5.0.0)
     jmespath (1.4.0)
+    jwt (2.2.2)
     listen (3.2.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -176,10 +184,31 @@ GEM
     mini_portile2 (2.4.0)
     minitest (5.14.2)
     msgpack (1.3.3)
+    multi_json (1.15.0)
+    multi_xml (0.6.0)
+    multipart-post (2.1.1)
     mysql2 (0.5.3)
     nio4r (2.5.3)
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
+    oauth2 (1.4.4)
+      faraday (>= 0.8, < 2.0)
+      jwt (>= 1.0, < 3.0)
+      multi_json (~> 1.3)
+      multi_xml (~> 0.5)
+      rack (>= 1.2, < 3)
+    omniauth (1.9.1)
+      hashie (>= 3.4.6)
+      rack (>= 1.6.2, < 3)
+    omniauth-facebook (7.0.0)
+      omniauth-oauth2 (~> 1.2)
+    omniauth-google-oauth2 (0.8.0)
+      jwt (>= 2.0)
+      omniauth (>= 1.1.1)
+      omniauth-oauth2 (>= 1.6)
+    omniauth-oauth2 (1.7.0)
+      oauth2 (~> 1.4)
+      omniauth (~> 1.9)
     orm_adapter (0.5.0)
     parallel (1.19.2)
     parser (2.7.1.4)
@@ -334,6 +363,7 @@ DEPENDENCIES
   capybara (>= 2.15)
   devise
   devise-i18n
+  dotenv-rails
   erb_lint
   factory_bot_rails
   faker!
@@ -342,6 +372,9 @@ DEPENDENCIES
   listen (~> 3.2)
   mini_magick
   mysql2 (>= 0.4.4)
+  omniauth
+  omniauth-facebook
+  omniauth-google-oauth2
   puma (~> 4.1)
   rails (~> 6.0.3, >= 6.0.3.2)
   rspec-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -202,10 +202,6 @@ GEM
       rack (>= 1.6.2, < 3)
     omniauth-facebook (7.0.0)
       omniauth-oauth2 (~> 1.2)
-    omniauth-google-oauth2 (0.8.0)
-      jwt (>= 2.0)
-      omniauth (>= 1.1.1)
-      omniauth-oauth2 (>= 1.6)
     omniauth-oauth2 (1.7.0)
       oauth2 (~> 1.4)
       omniauth (~> 1.9)
@@ -374,7 +370,6 @@ DEPENDENCIES
   mysql2 (>= 0.4.4)
   omniauth
   omniauth-facebook
-  omniauth-google-oauth2
   puma (~> 4.1)
   rails (~> 6.0.3, >= 6.0.3.2)
   rspec-rails

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -28,4 +28,8 @@ class ApplicationController < ActionController::Base
       }
     end
   end
+
+  def after_sign_in_path_for(resource)
+    user_path resource
+  end
 end

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -1,13 +1,11 @@
 class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   def facebook
-    # You need to implement the method below in your model (e.g. app/models/user.rb)
     @user = User.from_omniauth(request.env['omniauth.auth'])
-
     if @user.persisted?
       flash[:notice] = I18n.t 'devise.omniauth_callbacks.success', kind: 'Facebook'
       sign_in_and_redirect @user, event: :authentication
     else
-      session['devise.facebook_data'] = request.env['omniauth.auth'].except('extra') # Removing extra as it can overflow some session stores
+      session['devise.facebook_data'] = request.env['omniauth.auth'].except('extra')
       redirect_to new_user_registration_url, alert: @user.errors.full_messages.join("\n")
     end
   end

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -1,0 +1,14 @@
+class OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  def facebook
+    # You need to implement the method below in your model (e.g. app/models/user.rb)
+    @user = User.from_omniauth(request.env['omniauth.auth'])
+
+    if @user.persisted?
+      flash[:notice] = I18n.t 'devise.omniauth_callbacks.success', kind: 'Facebook'
+      sign_in_and_redirect @user, event: :authentication
+    else
+      session['devise.facebook_data'] = request.env['omniauth.auth'].except('extra') # Removing extra as it can overflow some session stores
+      redirect_to new_user_registration_url, alert: @user.errors.full_messages.join("\n")
+    end
+  end
+end

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -1,11 +1,12 @@
 class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   def facebook
     @user = User.from_omniauth(request.env['omniauth.auth'])
-    if @user.persisted?
+    if @user&.persisted?
       flash[:notice] = I18n.t 'devise.omniauth_callbacks.success', kind: 'Facebook'
       sign_in_and_redirect @user, event: :authentication
     else
       session['devise.facebook_data'] = request.env['omniauth.auth'].except('extra')
+      flash[:warnig] = "そのFacebookアカウントでは、ログインできませんでした。" if @user.nil?
       redirect_to new_user_registration_url, alert: @user.errors.full_messages.join("\n")
     end
   end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,5 +1,13 @@
 class RegistrationsController < Devise::RegistrationsController
-  before_action :configure_permitted_parameters
+  # パスワードなしで、変更できるようにカスタマイズ
+  def update
+    if @user.update(edit_params)
+      flash[:notice] = "ユーザー情報を編集しました"
+      redirect_to @user
+    else
+      render 'devise/registrations/edit'
+    end
+  end
 
   protected
 
@@ -11,18 +19,16 @@ class RegistrationsController < Devise::RegistrationsController
     user_path(resource)
   end
 
-  def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(
-      :account_update,
-      keys: [
-        :name,
-        :self_introduction,
-        :image,
-        :x,
-        :y,
-        :width,
-        :height,
-      ]
+  def edit_params
+    params.require(:user).permit(
+      :name,
+      :email,
+      :self_introduction,
+      :image,
+      :x,
+      :y,
+      :width,
+      :height
     )
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,10 @@
 class User < ApplicationRecord
+  # Include default devise modules. Others available are:
+  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
+  devise :database_authenticatable, :registerable,
+         :recoverable, :rememberable, :validatable,
+         :timeoutable, :omniauthable, omniauth_providers: [:google_oauth2, :facebook]
+
   has_many :jobs,    dependent: :destroy
   has_many :entries, dependent: :destroy
   has_many :receiving_messages,
@@ -13,17 +19,26 @@ class User < ApplicationRecord
 
   has_one_attached :image
 
-  # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable,
-         :timeoutable
-
   validates :name, presence: true, length: { maximum: 20 }
   validates :self_introduction,    length: { maximum: 2000 }
 
   validates :image, content_type: ['image/png', 'image/jpg', 'image/jpeg'],
                     size: { less_than: 5.megabytes, message: 'のデータサイズが大きすぎます' }
+
+  def self.from_omniauth(access_token)
+    data = access_token.info
+    user = User.where(email: data['email']).first
+
+    # Uncomment the section below if you want users to be created if they don't exist
+    unless user
+        user = User.create(
+          name: data['name'],
+          email: data['email'],
+          password: Devise.friendly_token[0,20]
+        )
+    end
+    user
+  end
 
   with_options presence: true, if: :was_attached? do
     validates :x

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -38,24 +38,6 @@
       <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
     <% end %>
 
-    <div class="field">
-      <%= f.label :password, "新しいパスワード" %> <i>(変更したい場合のみ)</i>
-      <%= f.password_field :password, autocomplete: "new-password" %>
-      <% if @minimum_password_length %>
-        <em>最小 <%= @minimum_password_length %> 文字から</em>
-      <% end %>
-    </div>
-
-    <div class="field">
-      <%= f.label "新しいパスワード(確認)" %>
-      <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-    </div>
-
-    <div class="field">
-      <%= f.label :current_password, "今のパスワード" %> <i>(変更したい場合、入力してください)</i>
-      <%= f.password_field :current_password, autocomplete: "current-password" %>
-    </div>
-
     <div class="actions">
       <%= f.submit "更新", id: "user_update_button" %>
     </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -27,5 +27,5 @@
     </div>
   <% end %>
 
-  <%= render "devise/shared/links" %>
+  <%#= render "devise/shared/links" %>
 </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,14 +1,11 @@
 <div class="form-box col-md-8">
   <h2>アカウント作成</h2>
-
   <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
     <%= render "devise/shared/error_messages", resource: resource %>
-
     <div class="field">
       <%= f.label :email, "メールアドレス" %>
       <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
     </div>
-
     <div class="field">
       <%= f.label :password, "パスワード" %>
       <% if @minimum_password_length %>
@@ -16,16 +13,18 @@
       <% end %>
       <%= f.password_field :password, autocomplete: "new-password" %>
     </div>
-
     <div class="field">
       <%= f.label :password_confirmation, "パスワード(確認)" %>
       <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
     </div>
-
     <div class="actions">
       <%= f.submit "作成", id: "user_create_button" %>
     </div>
   <% end %>
-
-  <%#= render "devise/shared/links" %>
+  <div class="external-api-box">
+    <%= button_to "Facebookでログイン",
+                  user_facebook_omniauth_authorize_path,
+                  id: "faceboook_login_button",
+                  class: "btn btn-primary" %>
+  </div>
 </div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,28 +1,28 @@
 <div class="form-box col-md-8 main-contents">
   <h2>ログイン</h2>
-
   <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
     <div class="field">
       <%= f.label :email, "メールアドレス" %>
       <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
     </div>
-
     <div class="field">
       <%= f.label :password, "パスワード" %>
       <%= f.password_field :password, autocomplete: "current-password" %>
     </div>
-
     <% if devise_mapping.rememberable? %>
       <div class="field">
         <%= f.check_box :remember_me %>
         <%= f.label :remember_me, "ログインしたままにする" %>
       </div>
     <% end %>
-
     <div class="actions">
       <%= f.submit "ログインする", id: "login_button" %>
     </div>
   <% end %>
-  <%= link_to "Sign in with Facebook", user_facebook_omniauth_authorize_path %>
-  <%#= render "devise/shared/links" %>
+  <div class="external-api-box">
+    <%= button_to "Facebookでログイン",
+                  user_facebook_omniauth_authorize_path,
+                  id: "faceboook_login_button",
+                  class: "btn btn-primary" %>
+  </div>
 </div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -23,6 +23,6 @@
       <%= f.submit "ログインする", id: "login_button" %>
     </div>
   <% end %>
-
-  <%= render "devise/shared/links" %>
+  <%= link_to "Sign in with Facebook", user_facebook_omniauth_authorize_path %>
+  <%#= render "devise/shared/links" %>
 </div>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -273,6 +273,7 @@ Devise.setup do |config|
   # up on your models and hooks.
   # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
 
+
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or
   # change the failure app, you can configure them inside the config.warden block.

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,0 +1,3 @@
+Rails.application.config.middleware.use OmniAuth::Builder do
+  provider :facebook, ENV['FACEBOOK_APP_ID'], ENV['FACEBOOK_APP_SECRET']
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,10 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   root to: 'jobs#index'
   get 'policy', to: 'basic_pages#policy'
-  devise_for :users, :controllers => { :registrations => :registrations }
+  devise_for :users, controllers: {
+    registrations: :registrations,
+    omniauth_callbacks: :omniauth_callbacks
+  }
   resources :users,    only: :show
   resources :jobs
   resources :entries,  only: [:create, :destroy]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,10 +4,10 @@ Rails.application.routes.draw do
   get 'policy', to: 'basic_pages#policy'
   devise_for :users, controllers: {
     registrations: :registrations,
-    omniauth_callbacks: :omniauth_callbacks
+    omniauth_callbacks: :omniauth_callbacks,
   }
-  resources :users,    only: :show
+  resources :users, only: :show
   resources :jobs
-  resources :entries,  only: [:create, :destroy]
+  resources :entries, only: [:create, :destroy]
   resources :messages, only: [:index, :new, :create, :show]
 end

--- a/db/migrate/20201009053419_add_clumns_to_users.rb
+++ b/db/migrate/20201009053419_add_clumns_to_users.rb
@@ -1,0 +1,8 @@
+class AddClumnsToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :provider, :string
+    add_column :users, :uid, :string
+
+    add_index :users, [:provider, :uid], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_20_103358) do
+ActiveRecord::Schema.define(version: 2020_10_09_053419) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -79,7 +79,10 @@ ActiveRecord::Schema.define(version: 2020_09_20_103358) do
     t.string "y"
     t.string "width"
     t.string "height"
+    t.string "provider"
+    t.string "uid"
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -3,5 +3,10 @@ FactoryBot.define do
     sequence(:name) { |n| "sample#{n}" }
     sequence(:email) { |n| "sample#{n}@example.com" }
     password { "password" }
+
+    factory :user_with_facebook do
+      provider { "facebook" }
+      sequence(:uid) { |n| "00000#{n}" }
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -76,5 +76,38 @@ RSpec.describe User, type: :model do
 
       it { expect(user.valid?).to be false }
     end
+
+    # 以下、外部API連携によるユーザ
+    context "when email:ok, provider:ok, uid: ok" do
+      let(:user) { build(:user_with_facebook) }
+
+      it { expect(user.valid?). to be true }
+    end
+
+    context "when email:nil, provider:ok, uid:ok" do
+      let(:user) { build(:user_with_facebook, email: nil) }
+
+      it { expect(user.valid?). to be true }
+    end
+
+    context "when email:ok, provider:nil, uid: ok" do
+      let(:user) { build(:user_with_facebook, provider: nil) }
+
+      it { expect(user.valid?). to be false }
+    end
+
+    context "when email:ok, provider:ok, uid: nil" do
+      let(:user) { build(:user_with_facebook, uid: nil) }
+
+      it { expect(user.valid?). to be false }
+    end
+
+    context "when duplicate combination of provider and uid" do
+      let(:user) { build(:user_with_facebook, uid: uid) }
+      let!(:duplicate_user) { create(:user_with_facebook, uid: uid) }
+      let(:uid) { "same_uid" }
+
+      it { expect(user.valid?). to be false }
+    end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -30,6 +30,10 @@ rescue ActiveRecord::PendingMigrationError => e
   puts e.to_s.strip
   exit 1
 end
+
+# OmniAuthをテストモードに変更
+OmniAuth.config.test_mode = true
+
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
@@ -66,4 +70,6 @@ RSpec.configure do |config|
 
   config.include Devise::Test::IntegrationHelpers, type: :request
   config.include Devise::Test::IntegrationHelpers, type: :system
+
+  config.include OmniauthMocks
 end

--- a/spec/requests/devise/registrations_spec.rb
+++ b/spec/requests/devise/registrations_spec.rb
@@ -20,18 +20,18 @@ RSpec.describe "Devise/Registrations", type: :request do
   end
 
   describe "#update" do
-    let!(:user) { create(:user, name: "before", self_introduction: "before", password: password) }
+    let!(:user) { create(:user) }
     let(:email_changed) { user.email + ".ch" }
-    let(:password) { "password" }
+    let(:after_name) { "after" }
+    let(:after_self_introduction) { "after content" }
 
     before do
       sign_in user
       put user_registration_path, params: {
         user: {
-          name: "after",
+          name: after_name,
           email: email_changed,
-          self_introduction: "after",
-          current_password: "password",
+          self_introduction: after_self_introduction,
         },
       }
     end
@@ -41,8 +41,9 @@ RSpec.describe "Devise/Registrations", type: :request do
 
     it "can update" do
       user_updated = User.find(user.id)
+      expect(user_updated.name).to eq after_name
       expect(user_updated.email).to eq email_changed
-      expect(user_updated.name).to eq "after"
+      expect(user_updated.self_introduction).to eq after_self_introduction
     end
   end
 end

--- a/spec/requests/omniauth_callbacks_request_spec.rb
+++ b/spec/requests/omniauth_callbacks_request_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "OmniauthCallbacks", type: :request do
       let(:user) { create(:user_with_facebook) }
 
       before do
-        Rails.application.env_config['omniauth.auth'] = facebook_mock(user)
+        facebook_mock(user)
         get user_facebook_omniauth_callback_path
       end
 
@@ -18,7 +18,7 @@ RSpec.describe "OmniauthCallbacks", type: :request do
       let(:user) { build(:user_with_facebook) }
 
       before do
-        Rails.application.env_config['omniauth.auth'] = facebook_mock(user)
+        facebook_mock(user)
         get user_facebook_omniauth_callback_path
       end
 
@@ -30,7 +30,7 @@ RSpec.describe "OmniauthCallbacks", type: :request do
       let(:user) { build(:user_with_facebook) }
 
       before do
-        Rails.application.env_config['omniauth.auth'] = facebook_invalid_mock(user)
+        facebook_invalid_mock(user)
         get user_facebook_omniauth_callback_path
       end
 

--- a/spec/requests/omniauth_callbacks_request_spec.rb
+++ b/spec/requests/omniauth_callbacks_request_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe "OmniauthCallbacks", type: :request do
+  describe "#facebook" do
+    context "when user is created" do
+      let(:user) { create(:user_with_facebook) }
+
+      before do
+        Rails.application.env_config['omniauth.auth'] = facebook_mock(user)
+        get user_facebook_omniauth_callback_path
+      end
+
+      it { expect(response.status).to eq(302) }
+      it { expect(response).to redirect_to user_path(user) }
+    end
+
+    context "when user is not created" do
+      let(:user) { build(:user_with_facebook) }
+
+      before do
+        Rails.application.env_config['omniauth.auth'] = facebook_mock(user)
+        get user_facebook_omniauth_callback_path
+      end
+
+      it { expect(response.status).to eq(302) }
+      it { expect(response).to redirect_to user_path(User.find_by(email: user.email)) }
+    end
+
+    context "when facebook_mock is invalid" do
+      let(:user) { build(:user_with_facebook) }
+
+      before do
+        Rails.application.env_config['omniauth.auth'] = facebook_invalid_mock(user)
+        get user_facebook_omniauth_callback_path
+      end
+
+      it { expect(response.status).to eq(302) }
+      it { expect(response).to redirect_to new_user_registration_url }
+    end
+  end
+end

--- a/spec/support/omniauth_mocks.rb
+++ b/spec/support/omniauth_mocks.rb
@@ -9,12 +9,12 @@ module OmniauthMocks
         first_name: 'Joe',
         last_name: 'Bloggs',
         image: 'http://graph.facebook.com/1234567/picture?type=square',
-        verified: true
+        verified: true,
       },
       credentials: {
-        token: 'ABCDEF...', # OAuth 2.0 access_token, which you may wish to store
-        expires_at: 1321747205, # when the access token expires (it always will)
-        expires: true # this will always be true
+        token: 'ABCDEF...',
+        expires_at: 1321747205,
+        expires: true,
       },
       extra: {
         raw_info: {
@@ -30,9 +30,9 @@ module OmniauthMocks
           timezone: -8,
           locale: 'en_US',
           verified: true,
-          updated_time: '2011-11-11T06:21:03+0000'
-        }
-      }
+          updated_time: '2011-11-11T06:21:03+0000',
+        },
+      },
     })
   end
 
@@ -46,12 +46,12 @@ module OmniauthMocks
         first_name: 'Joe',
         last_name: 'Bloggs',
         image: 'http://graph.facebook.com/1234567/picture?type=square',
-        verified: true
+        verified: true,
       },
       credentials: {
-        token: 'ABCDEF...', # OAuth 2.0 access_token, which you may wish to store
-        expires_at: 1321747205, # when the access token expires (it always will)
-        expires: true # this will always be true
+        token: 'ABCDEF...',
+        expires_at: 1321747205,
+        expires: true,
       },
       extra: {
         raw_info: {
@@ -67,9 +67,9 @@ module OmniauthMocks
           timezone: -8,
           locale: 'en_US',
           verified: true,
-          updated_time: '2011-11-11T06:21:03+0000'
-        }
-      }
+          updated_time: '2011-11-11T06:21:03+0000',
+        },
+      },
     })
   end
 end

--- a/spec/support/omniauth_mocks.rb
+++ b/spec/support/omniauth_mocks.rb
@@ -1,0 +1,75 @@
+module OmniauthMocks
+  def facebook_mock(user)
+    OmniAuth.config.mock_auth[:facebook] = OmniAuth::AuthHash.new({
+      provider: 'facebook',
+      uid: user.uid,
+      info: {
+        email: user.email,
+        name: user.name,
+        first_name: 'Joe',
+        last_name: 'Bloggs',
+        image: 'http://graph.facebook.com/1234567/picture?type=square',
+        verified: true
+      },
+      credentials: {
+        token: 'ABCDEF...', # OAuth 2.0 access_token, which you may wish to store
+        expires_at: 1321747205, # when the access token expires (it always will)
+        expires: true # this will always be true
+      },
+      extra: {
+        raw_info: {
+          id: user.uid,
+          name: user.name,
+          first_name: 'Joe',
+          last_name: 'Bloggs',
+          link: 'http://www.facebook.com/jbloggs',
+          username: 'jbloggs',
+          location: { id: '123456789', name: 'Palo Alto, California' },
+          gender: 'male',
+          email: 'joe@bloggs.com',
+          timezone: -8,
+          locale: 'en_US',
+          verified: true,
+          updated_time: '2011-11-11T06:21:03+0000'
+        }
+      }
+    })
+  end
+
+  def facebook_invalid_mock(user)
+    OmniAuth.config.mock_auth[:facebook] = OmniAuth::AuthHash.new({
+      provider: '',
+      uid: '',
+      info: {
+        email: user.email,
+        name: user.name,
+        first_name: 'Joe',
+        last_name: 'Bloggs',
+        image: 'http://graph.facebook.com/1234567/picture?type=square',
+        verified: true
+      },
+      credentials: {
+        token: 'ABCDEF...', # OAuth 2.0 access_token, which you may wish to store
+        expires_at: 1321747205, # when the access token expires (it always will)
+        expires: true # this will always be true
+      },
+      extra: {
+        raw_info: {
+          id: '',
+          name: user.name,
+          first_name: 'Joe',
+          last_name: 'Bloggs',
+          link: 'http://www.facebook.com/jbloggs',
+          username: 'jbloggs',
+          location: { id: '123456789', name: 'Palo Alto, California' },
+          gender: 'male',
+          email: 'joe@bloggs.com',
+          timezone: -8,
+          locale: 'en_US',
+          verified: true,
+          updated_time: '2011-11-11T06:21:03+0000'
+        }
+      }
+    })
+  end
+end

--- a/spec/system/devise/registrations_spec.rb
+++ b/spec/system/devise/registrations_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe "Devise/Registrations", type: :system do
   let!(:user) { create(:user) }
   let!(:new_user) { build(:user) }
+  let(:user_with_facebook) { build(:user_with_facebook) }
   let(:password) { "password" }
   let(:user_with_image_info) { create(:user, x: 0, y: 0, width: 50, height: 50) }
   let(:first_image_path) { 'spec/factories/file_data/jpg_file.jpg' }
@@ -32,6 +33,28 @@ RSpec.describe "Devise/Registrations", type: :system do
     end
     expect(page).to have_selector '.alert-success'
     expect(page).to have_current_path user_path(User.find_by(email: new_user.email))
+  end
+
+  it "make user with facebook" do
+    facebook_mock(user_with_facebook)
+    # ここまでの経路は"make user"で確認済み"
+    visit new_user_registration_path
+    expect do
+      click_on 'faceboook_login_button'
+    end.to change(User, :count).by(1)
+    expect(page).to have_selector '.alert-success'
+    expect(page).to have_current_path user_path(User.find_by(email: user_with_facebook.email))
+  end
+
+  it "cannot make user with facebook" do
+    facebook_invalid_mock(user_with_facebook)
+    # ここまでの経路は"make user"で確認済み"
+    visit new_user_registration_path
+    expect do
+      click_on 'faceboook_login_button'
+    end.to change(User, :count).by(0)
+    expect(page).to have_selector '.alert-warning'
+    expect(page).to have_current_path new_user_registration_path
   end
 
   it "update user" do

--- a/spec/system/devise/registrations_spec.rb
+++ b/spec/system/devise/registrations_spec.rb
@@ -1,10 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe "Devise/Registrations", type: :system do
-  let!(:user) { create(:user, password: password) }
-  let!(:new_user) { build(:user, password: password) }
-  let(:user_with_image_info) { create(:user, x: 0, y: 0, width: 50, height: 50) }
+  let!(:user) { create(:user) }
+  let!(:new_user) { build(:user) }
   let(:password) { "password" }
+  let(:user_with_image_info) { create(:user, x: 0, y: 0, width: 50, height: 50) }
   let(:first_image_path) { 'spec/factories/file_data/jpg_file.jpg' }
   let(:changed_image_path) { 'spec/factories/file_data/another_file.png' }
 
@@ -41,17 +41,18 @@ RSpec.describe "Devise/Registrations", type: :system do
     # 不正な入力
     within(:css, '.form-box') do
       fill_in('user_name', with: name_changed)
-      fill_in('user_current_password', with: "invalid")
+      fill_in('user_email', with: " ")
       click_on 'user_update_button'
       expect(page).to have_selector 'h2', text: "プロフィール編集"
       expect(page).to have_selector '#error_explanation'
     end
     # 正しい入力
     within(:css, '.form-box') do
-      fill_in('user_email', with: "valid@example.com")
-      fill_in('user_current_password', with: password)
+      fill_in('user_name', with: name_changed)
+      fill_in('user_email', with: user.email)
       click_on 'user_update_button'
     end
+    expect(page).to have_content name_changed
     expect(page).to have_selector '.alert-success'
     expect(page).to have_current_path user_path(user)
   end
@@ -76,7 +77,6 @@ RSpec.describe "Devise/Registrations", type: :system do
       expect(page).not_to have_selector '.cropper-container'
       attach_file('user_image', first_image_path)
       fill_in('user_name', with: user.name)
-      fill_in('user_current_password', with: password)
       expect(page).to have_selector '.cropper-container'
       click_on 'user_update_button'
     end
@@ -100,7 +100,7 @@ RSpec.describe "Devise/Registrations", type: :system do
       expect(page).not_to have_selector '.cropper-container'
       attach_file('user_image', changed_image_path)
       fill_in('user_name', with: user_with_image_info.name)
-      fill_in('user_current_password', with: "invalid")
+      fill_in('user_email', with: " ")
       expect(page).to have_selector '.cropper-container'
       click_on 'user_update_button'
       expect(page).to have_selector 'h2', text: "プロフィール編集"
@@ -111,9 +111,9 @@ RSpec.describe "Devise/Registrations", type: :system do
       # 最初に設定した画像がプレビューとして表示される
       expect(page).to have_selector "img[src$='jpg_file.jpg']"
       expect(page).not_to have_selector "img[src$='another_file.png']"
+      fill_in('user_email', with: user_with_image_info.email)
       attach_file('user_image', changed_image_path)
       fill_in('user_name', with: user_with_image_info.name)
-      fill_in('user_current_password', with: password)
       click_on 'user_update_button'
     end
     # 画像の変更を確認

--- a/spec/system/devise/sessions_spec.rb
+++ b/spec/system/devise/sessions_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe "Devise/Sessions", type: :system do
   let!(:user) { create(:user, password: password) }
+  let(:user_with_facebook) { create(:user_with_facebook) }
   let(:password) { "password" }
 
   it "make session" do
@@ -25,7 +26,25 @@ RSpec.describe "Devise/Sessions", type: :system do
       click_on 'login_button'
     end
     expect(page).to have_selector '.alert-success'
-    expect(page).to have_current_path root_path
+    expect(page).to have_current_path user_path(user)
+  end
+
+  it "make session with facebook" do
+    facebook_mock(user_with_facebook)
+    # ここまでの経路は"make sessionで確認済み"
+    visit new_user_session_path
+    click_on 'faceboook_login_button'
+    expect(page).to have_selector '.alert-success'
+    expect(page).to have_current_path user_path(user_with_facebook)
+  end
+
+  it "cannot make session with facebook" do
+    facebook_invalid_mock(user_with_facebook)
+    # ここまでの経路は"make user"で確認済み"
+    visit new_user_registration_path
+    click_on 'faceboook_login_button'
+    expect(page).to have_selector '.alert-warning'
+    expect(page).to have_current_path new_user_registration_path
   end
 
   it "delete session" do


### PR DESCRIPTION
外部APIによる認証機能を追加しました(facebook)
仕様上の注意を下記にまとめました。

### ユーザーの識別の方法を変更
emailがユニークであること
→→
emailがユニーク＊①　または　providerとuidの組み合わせがユニーク＊②

＊①emailとパスワードを利用したログイン
＊②が外部APIを利用したログイン

### ユーザー情報の更新において、パスワード欄を消去
外部APIを利用したユーザーが更新できるように。
(外部APIを利用したログイン時、パスワードは自動で生成されるため、ユーザーは自分のパスワードを知らない)